### PR TITLE
Update sax-machine for ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "spec"
 require "spec/rake/spectask"
-require 'lib/sax-machine.rb'
 
 Spec::Rake::SpecTask.new do |t|
   t.spec_opts = ['--options', "\"#{File.dirname(__FILE__)}/spec/spec.opts\""]

--- a/lib/sax-machine/sax_document.rb
+++ b/lib/sax-machine/sax_document.rb
@@ -26,8 +26,8 @@ module SAXMachine
       # we only want to insert the getter and setter if they haven't defined it from elsewhere.
       # this is how we allow custom parsing behavior. So you could define the setter
       # and have it parse the string into a date or whatever.
-      attr_reader options[:as] unless instance_methods.include?(options[:as].to_s)
-      attr_writer options[:as] unless instance_methods.include?("#{options[:as]}=")
+      attr_reader options[:as] unless instance_methods.detect{|im| im.to_s == options[:as].to_s }
+      attr_writer options[:as] unless instance_methods.detect{|im| im.to_s == "#{options[:as]}="}
     end
 
     def columns
@@ -63,7 +63,7 @@ module SAXMachine
         sax_config.add_top_level_element(name, options.merge(:collection => true))
       end
       
-      if !instance_methods.include?(options[:as].to_s)
+      if !instance_methods.detect{|im| im.to_s == options[:as].to_s }
       class_eval <<-SRC
           def #{options[:as]}
             @#{options[:as]} ||= []
@@ -71,7 +71,7 @@ module SAXMachine
         SRC
       end
       
-      attr_writer options[:as] unless instance_methods.include?("#{options[:as]}=")
+      attr_writer options[:as] unless instance_methods.detect{|im| im.to_s == "#{options[:as]}="}
     end
     
     def sax_config

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 describe "SAXMachine" do
   describe "element" do
@@ -19,7 +19,20 @@ describe "SAXMachine" do
       it "should allow introspection of the elements" do
         @klass.column_names.should =~ [:title]
       end
-
+      
+      it "should not overwrite the getter is there is already one present" do
+        @klass = Class.new do
+          def title
+            "#{@title} ***"
+          end
+          include SAXMachine
+          element :title
+        end
+        document = @klass.new
+        document.title = "Title"
+        document.title.should == "Title ***"
+      end
+      
       it "should not overwrite the setter if there is already one present" do
         @klass = Class.new do
           def title=(val)
@@ -32,6 +45,7 @@ describe "SAXMachine" do
         document.title = "Title"
         document.title.should == "Title **"
       end
+      
       describe "the class attribute" do
         before(:each) do
           @klass = Class.new do
@@ -105,6 +119,33 @@ describe "SAXMachine" do
         document.name.should == "Paul"
         document.title.should == "My Title"
       end
+      
+      it "should not overwrite the getter is there is already one present" do
+        @klass = Class.new do
+          def items
+            []
+          end
+          include SAXMachine
+          elements :items
+        end
+        document = @klass.new
+        document.items = [1,2,3,4]
+        document.items.should == []
+      end
+      
+      it "should not overwrite the setter if there is already one present" do
+        @klass = Class.new do
+          def items=(val)
+            @items = [1, *val]
+          end
+          include SAXMachine
+          elements :items
+        end
+        document = @klass.new
+        document.items = [2,3]
+        document.items.should == [1,2,3]
+      end
+      
     end
 
     describe "when using options for parsing elements" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "rubygems"
 require "spec"
+require "date"
 
 # gem install redgreen for colored test output
 begin require "redgreen" unless ENV['TM_CURRENT_LINE']; rescue LoadError; end
@@ -7,7 +8,7 @@ begin require "redgreen" unless ENV['TM_CURRENT_LINE']; rescue LoadError; end
 path = File.expand_path(File.dirname(__FILE__) + "/../lib/")
 $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 
-require "lib/sax-machine"
+require "sax-machine"
 
 # Spec::Runner.configure do |config|
 # end


### PR DESCRIPTION
The element/elements functionality was breaking in Ruby 1.9 because #instance_methods returns symbols instead of strings.
