### PR TITLE
nokogiri 1.4.4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.bundle
+*.gem

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require=./spec/spec_helper.rb
+--color

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm --create use 1.8.7@sax-machine

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem 'nokogiri', '>= 1.4.4'
+gem 'rspec', '>= 2.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.2)
+    nokogiri (1.4.4)
+    rspec (2.4.0)
+      rspec-core (~> 2.4.0)
+      rspec-expectations (~> 2.4.0)
+      rspec-mocks (~> 2.4.0)
+    rspec-core (2.4.0)
+    rspec-expectations (2.4.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (>= 1.4.4)
+  rspec (>= 2.4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,7 @@
-require "spec"
-require "spec/rake/spectask"
 require 'lib/sax-machine.rb'
 
-Spec::Rake::SpecTask.new do |t|
-  t.spec_opts = ['--options', "\"#{File.dirname(__FILE__)}/spec/spec.opts\""]
-  t.spec_files = FileList['spec/**/*_spec.rb']
+task :test do
+    sh 'rspec spec'
 end
 
 task :install do

--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -19,6 +19,7 @@ module SAXMachine
     end
 
     def start_element(name, attrs = [])
+      attrs.flatten!
       object, config, value = stack.last
       sax_config = object.class.respond_to?(:sax_config) ? object.class.sax_config : nil
 

--- a/sax-machine.gemspec
+++ b/sax-machine.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{sax-machine}
+  s.name = %q{sax-machine-nokogiri-1.4.4-safe}
   s.version = "0.0.15"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
     "lib/sax-machine/sax_document.rb",
     "lib/sax-machine/sax_handler.rb",
     "README.textile", "Rakefile",
-    "spec/spec.opts",
+    ".rspec",
+    "Gemfile", "Gemfile.lock",
     "spec/spec_helper.rb",
     "spec/sax-machine/sax_document_spec.rb"]
   s.homepage = %q{http://github.com/pauldix/sax-machine}

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,2 +1,0 @@
---diff
---color

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
-require "rubygems"
-require "spec"
+require 'date'
 
 # gem install redgreen for colored test output
 begin require "redgreen" unless ENV['TM_CURRENT_LINE']; rescue LoadError; end


### PR DESCRIPTION
Hi,
I've added a one-liner to fix sax-machine to support Nokogiri 1.4.4.

I've also upgraded added rvm & bundler support and upgraded rspec - just for house keeping.

In the meantime, I've published the gem under "sax-machine-nokogiri-1.4.4-safe". I'll happily remove this if you are able to publish an official version supporting the latest Nokogiri.

Cheers :D
