### PR TITLE
collection element text

### DIFF
--- a/lib/sax-machine/sax_element_config.rb
+++ b/lib/sax-machine/sax_element_config.rb
@@ -31,6 +31,12 @@ module SAXMachine
         @data_class = options[:class]
         @required = options[:required]
       end
+      def value_configured?
+        !@value.nil?
+      end
+      def to_s
+        "name: #{@name} dataclass: #{@data_class} setter: #{@setter} required: #{@required} value: #{@value} as:#{@as} collection: #{@collection} with: #{@with}"
+      end
 
       def column
         @as || @name.to_sym

--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -46,6 +46,10 @@ module SAXMachine
 
       unless parsed_config?(object, config)
         if config.respond_to?(:accessor)
+          subconfig = element.class.sax_config if element.class.respond_to?(:sax_config)
+          if econf = subconfig.element_config_for_tag(name,[])
+            element.send(econf.setter, value) unless econf.value_configured?
+          end
           object.send(config.accessor) << element
         else
           value = config.data_class ? element : value

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -385,19 +385,18 @@ describe "SAXMachine" do
       it "should parse elements, and make attributes and inner text available" do
         class Related
           include SAXMachine
-          element 'related', :as=>'name'
-          element 'related', :as=>'attrval', :value=>'attrval'
+          element 'related', :as=>:item
+          element 'related', :as=>:attr, :value=>'attr'
         end
         class Foo
           elements 'related', :as=>'items', :class=>Related
         end
 
-        doc = Foo.parse(%{<xml><collection><related attrval='bar'>something</related><related attrval='baz'>somethingelse</related></collection></xml>})
+        doc = Foo.parse(%{<xml><collection><related attr='baz'>something</related><related>somethingelse</related></collection></xml>})
         doc.items.first.should_not be_nil
-        doc.items.first.attrval.should == 'bar'
-        doc.items.last.attrval.should == 'baz'
-        doc.items.last.name.should == 'something'
-        doc.items.last.name.should == 'somethingelse'
+        doc.items.size.should == 2
+        doc.items.first.item.should == 'something'
+        doc.items.last.item.should == 'somethingelse'
 
       end
 
@@ -412,7 +411,6 @@ describe "SAXMachine" do
         document.entries.first.url.should == "http://pauldix.net"
       end
     end
-
   end
 
   describe "full example" do


### PR DESCRIPTION
this patch & test case makes it possible to set the value of a collection element to the inner text of the element.

the upshot is that the inner text is set as the value unless there's a :value configuration option set in the element configuration.

i had a bit of difficulty deciphering the code, so this is likely barely adequate, but all the test cases still pass.
