### PR TITLE
dash in element names

### DIFF
--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -19,6 +19,7 @@ module SAXMachine
     end
 
     def start_element(name, attrs = [])
+      name.gsub!(/\-/,'_')
       attrs.flatten!
       object, config, value = stack.last
       sax_config = object.class.respond_to?(:sax_config) ? object.class.sax_config : nil
@@ -41,6 +42,7 @@ module SAXMachine
     end
 
     def end_element(name)
+      name.gsub!(/\-/,'_')
       (object, tag_config, _), (element, config, value) = stack[-2..-1]
       return unless stack.size > 1 && config && config.name.to_s == name.to_s
 


### PR DESCRIPTION
Having to deal with xml generated by ActiveSupport (that tends to _dasherize_ its output) and other web services (e.g. socialcast, who likes to have elements like permalink-url), I chose to substitute dashes with underscores in element names, so that they can be mapped via the sax-machine dsl.
