### PR TITLE
Updated readme with example of pulling attributes and inner value within 

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -13,6 +13,15 @@ h2. Usage
 <pre>
 require 'sax-machine'
 
+# Class for information associated with content parts in a feed.
+#  Ex: <content type="text">sample</content>
+#  instance.type will be "text", instance.text will be "sample"
+class AtomContent
+  include SAXMachine
+  attribute :type
+  value :text
+end
+
 # Class for parsing an atom entry out of a feedburner atom feed
 class AtomEntry
   include SAXMachine
@@ -21,7 +30,7 @@ class AtomEntry
   element :name, :as => :author
   element "feedburner:origLink", :as => :url
   element :summary
-  element :content
+  element :content, :class => AtomContent
   element :published
   parent :parent
 end


### PR DESCRIPTION
Included an example of the change from pull #13.  It is an example of pulling the content and the type along with it.

Example:

``` xml
<content type="text">sample</content>
```

With code:

``` ruby
class AtomContent
  include SAXMachine
  attribute :type
  value :text
end

instance.type # => "text"
instance.text # => "sample"
```
