### PR TITLE
Allows for acts_as_* paradigm for use in Rails plugins.

### DIFF
--- a/lib/sax-machine/sax_document.rb
+++ b/lib/sax-machine/sax_document.rb
@@ -15,6 +15,11 @@ module SAXMachine
 
   module ClassMethods
 
+    def included(base)
+      base.extend ClassMethods
+      base.sax_config.send(:initialize_copy, self.sax_config)
+    end
+
     def inherited(subclass)
       subclass.sax_config.send(:initialize_copy, self.sax_config)
     end

--- a/spec/sax-machine/include_sax_machine_spec.rb
+++ b/spec/sax-machine/include_sax_machine_spec.rb
@@ -1,5 +1,26 @@
 require 'spec_helper'
 
+class BaseClass; end
+module Something
+  def self.included(base)
+    base.send :extend, ClassMethods
+  end
+
+  module ClassMethods
+    def acts_as_sax
+      self.send :include, Parser
+    end
+  end
+end
+
+module Parser
+  include SAXMachine
+  element :title
+end
+
+# Gives BaseClass#acts_as_sax
+BaseClass.send :include, Something
+
 class A
   include SAXMachine
   element :title
@@ -13,6 +34,10 @@ class C < B
   element :c
 end
 
+class D < BaseClass
+  acts_as_sax
+end
+
 describe "SAXMachine inheritance" do
   before do
     xml = "<top><title>Test</title><b>Matched!</b><c>And Again</c></top>"
@@ -22,6 +47,8 @@ describe "SAXMachine inheritance" do
     @b.parse xml
     @c = C.new
     @c.parse xml
+    @d = D.new
+    @d.parse xml
   end
   it { @a.should be_a(A) }
   it { @a.should_not be_a(B) }
@@ -39,4 +66,7 @@ describe "SAXMachine inheritance" do
   it { @c.title.should == "Test" }
   it { @c.b.should == "Matched!" }
   it { @c.c.should == "And Again" }
+  it { @d.should be_a(D) }
+  it { @d.should be_a(SAXMachine) }
+  it { @d.title.should == "Test" }
 end


### PR DESCRIPTION
I am working on creating a Rails plugin for Feedzirra by trying to make an ActiveRecord::Base#acts_as_parser class method to make any ActiveRecord object behave as though it is a Feedzirra::Parser so it can be added as a feed class to Feedzirra::Feed.

Anyways, in order to accomplish this I have written the attached code. I think it works, feedback and any help would be appreciated.
