### PR TITLE
Added support for Integer and Float Element Classes

### DIFF
--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -41,7 +41,13 @@ module SAXMachine
           end
         end
         if !collection_config && element_config = sax_config.element_config_for_tag(name, attrs)
-          new_object = element_config.data_class ? element_config.data_class.new : object
+          new_object = case element_config.data_class.to_s
+          when 'Integer' then 0
+          when 'Float'   then 0.0
+          when ''        then object
+          else
+            element_config.data_class.new
+          end
           stack.push [new_object, element_config, String.new]
 
           if (attribute_config = new_object.class.respond_to?(:sax_config) && new_object.class.sax_config.attribute_configs_for_element(attrs))
@@ -67,7 +73,14 @@ module SAXMachine
           end
           object.send(config.accessor) << element
         else
-          value = config.data_class ? element : value
+          value =  case config.data_class.to_s
+          when 'String'  then value.to_s
+          when 'Integer' then value.to_i
+          when 'Float'   then value.to_f
+          when ''        then value
+          else
+            element
+          end
           object.send(config.setter, value) unless value == ""
           mark_as_parsed(object, config)
         end

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -59,6 +59,34 @@ describe "SAXMachine" do
         it "should be available" do
           @klass.data_class(:date).should == DateTime
         end
+        
+        it "should handle an integer class" do
+          @klass = Class.new do
+            include SAXMachine
+            element :number, :class => Integer
+          end
+          document = @klass.parse("<number>5</number>")
+          document.number.should == 5
+        end
+        
+        it "should handle an float class" do
+          @klass = Class.new do
+            include SAXMachine
+            element :number, :class => Float
+          end
+          document = @klass.parse("<number>5.5</number>")
+          document.number.should == 5.5
+        end        
+
+        it "should handle an string class" do
+          @klass = Class.new do
+            include SAXMachine
+            element :number, :class => String
+          end
+          document = @klass.parse("<number>5.5</number>")
+          document.number.should == "5.5"
+        end
+        
       end
       describe "the required attribute" do
         it "should be available" do
@@ -385,7 +413,7 @@ describe "SAXMachine" do
           elements :item, :as => :items, :with => {:type => 'Foo'}, :class => Foo
         end
       end
-
+      
       it "should cast into the correct class" do
         document = @klass.parse("<items><item type=\"Bar\"><title>Bar title</title></item><item type=\"Foo\"><title>Foo title</title></item></items>")
         document.items.size.should == 2


### PR DESCRIPTION
I added support for Integer and Float classes to the SAX handler.  Should be helpful when parsing documents with a lot of numbers -- which I do.

Thanks!
