### PR TITLE
Encoding mismatch between document and elements

### DIFF
--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -13,13 +13,15 @@ module SAXMachine
     end
 
     def characters(string)
-      object, config, value = stack.last
-      value << string
-    end
+      value = stack.last[2]
 
-    def cdata_block(string)
-      characters(string)
+      if value.empty?
+        stack.last[2] = string.dup
+      else
+        value << string
+      end
     end
+    alias cdata_block characters
 
     def start_element(name, attrs = [])
       name.gsub!(/\-/,'_')

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -126,6 +126,16 @@ describe "SAXMachine" do
         document.title.should == "My Title"
       end
 
+      if RUBY_VERSION >= "1.9.0"
+        it "should keep the document encoding for elements" do
+          data = "<title>My Title</title>"
+          data.encode!("utf-8")
+
+          document = @klass.parse(data)
+          document.title.encoding.should == data.encoding
+        end
+      end
+
       it "should save cdata into an accessor" do
         document = @klass.parse("<title><![CDATA[A Title]]></title>")
         document.title.should == "A Title"


### PR DESCRIPTION
I'm looking into an encoding issue on 1.9.3. Basically the document is UTF-8 (html) but the elements are coming out with the ASCII-8BIT (binary) encoding. It's causing issues down the line since ASCII-8BIT isn't always considered text.

Should text elements match the document encoding?

Example:

``` ruby
class Model
  include SAXMachine

  element :title
end

data = "<title>Title</title>"
data.encode!("UTF-8")
data.encoding # => <Encoding:UTF-8>

model = Model.parse(data)
mode.title.encoding # => <Encoding:ASCII-8BIT>
```
