### PR TITLE
Allow with option to accept string or regular expression

### DIFF
--- a/lib/sax-machine/sax_attribute_config.rb
+++ b/lib/sax-machine/sax_attribute_config.rb
@@ -20,11 +20,11 @@ module SAXMachine
       end
 
       def value_from_attrs(attrs)
-        attrs.index(@name) ? attrs[attrs.index(@name) + 1] : nil
+        attrs.fetch(@name, nil)
       end
 
       def attrs_match?(attrs)
-        attrs.index(@name) ? true : false
+        attrs.key?(@name) || attrs.value?(@name)
       end
 
       def has_value_and_attrs_match?(attrs)

--- a/lib/sax-machine/sax_collection_config.rb
+++ b/lib/sax-machine/sax_collection_config.rb
@@ -5,16 +5,10 @@ module SAXMachine
       attr_reader :name
       
       def initialize(name, options)
-        @name   = name.to_s
-        @class  = options[:class]
-        @as     = options[:as].to_s
-        
-        if options.has_key?(:with)
-          # for faster comparisons later
-          @with = options[:with].to_a.flatten.collect {|o| o.to_s}
-        else
-          @with = nil
-        end
+        @name  = name.to_s
+        @class = options[:class]
+        @as    = options[:as].to_s
+        @with  = options.fetch(:with, {})
       end
       
       def accessor
@@ -22,10 +16,8 @@ module SAXMachine
       end
       
       def attrs_match?(attrs)
-        if @with
-          @with == (@with & attrs)
-        else
-          true
+        @with.all? do |key, value|
+          value === attrs[key.to_s]
         end
       end
 

--- a/lib/sax-machine/sax_element_config.rb
+++ b/lib/sax-machine/sax_element_config.rb
@@ -6,14 +6,8 @@ module SAXMachine
       
       def initialize(name, options)
         @name = name.to_s
-        
-        if options.has_key?(:with)
-          # for faster comparisons later
-          @with = options[:with].to_a.flatten.collect {|o| o.to_s}
-        else
-          @with = nil
-        end
-        
+        @with = options.fetch(:with, {})
+
         if options.has_key?(:value)
           @value = options[:value].to_s
         else
@@ -49,14 +43,12 @@ module SAXMachine
       end
 
       def value_from_attrs(attrs)
-        attrs.index(@value) ? attrs[attrs.index(@value) + 1] : nil
+        attrs.fetch(@value, nil)
       end
       
       def attrs_match?(attrs)
-        if @with
-          @with == (@with & attrs)
-        else
-          true
+        @with.all? do |key, value|
+          value === attrs[key.to_s]
         end
       end
       

--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -32,7 +32,6 @@ module SAXMachine
     alias cdata_block characters
 
     def start_element(name, attrs = [])
-      attrs.flatten!
 
       name   = normalize_name(name)
       node   = stack.last
@@ -41,6 +40,8 @@ module SAXMachine
       sax_config = sax_config_for(object)
 
       if sax_config
+        attrs = Hash[attrs]
+
         if collection_config = sax_config.collection_config(name, attrs)
           object     = collection_config.data_class.new
           sax_config = sax_config_for(object)

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -306,6 +306,35 @@ describe "SAXMachine" do
             document.second.should == "second match"
           end
         end
+
+        describe "with only one element as a regular expression" do
+          before :each do
+            @klass = Class.new do
+              include SAXMachine
+              element :link, :with => {:foo => /ar$/}
+            end
+          end
+
+          it "should save the text of an element that has matching attributes" do
+            document = @klass.parse("<link foo=\"bar\">match</link>")
+            document.link.should == "match"
+          end
+
+          it "should not save the text of an element that doesn't have matching attributes" do
+            document = @klass.parse("<link>no match</link>")
+            document.link.should be_nil
+          end
+
+          it "should save the text of an element that has matching attributes when it is the second of that type" do
+            document = @klass.parse("<xml><link>no match</link><link foo=\"bar\">match</link></xml>")
+            document.link.should == "match"
+          end
+
+          it "should save the text of an element that has matching attributes plus a few more" do
+            document = @klass.parse("<xml><link>no match</link><link asdf='jkl' foo='bar'>match</link>")
+            document.link.should == "match"
+          end
+        end
       end # using the 'with' option
 
       describe "using the 'value' option" do
@@ -429,7 +458,7 @@ describe "SAXMachine" do
         @klass = Class.new do
           include SAXMachine
           elements :item, :as => :items, :with => {:type => 'Bar'}, :class => Bar
-          elements :item, :as => :items, :with => {:type => 'Foo'}, :class => Foo
+          elements :item, :as => :items, :with => {:type => /Foo/}, :class => Foo
         end
       end
       


### PR DESCRIPTION
Had a need on a client project for partial pattern matching an attribute on a node.  Current implementation requires a full match.  /cc @albus522
