### PR TITLE
Fixed 1.8.7 compatibility

### DIFF
--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -54,7 +54,7 @@ describe "SAXMachine" do
             element :date, :class => DateTime
           end
           @document = @klass.new
-          @document.date = DateTime.now.to_s
+          @document.date = Time.now.iso8601
         end
         it "should be available" do
           @klass.data_class(:date).should == DateTime


### PR DESCRIPTION
Changed RSpec test from `DateTime.now.to_s` to `Time.now.iso8601` to make 1.8.7
tests pass again.
