### PR TITLE
Removed @parsed_configs and storing if parsed in object. Fixed leak!

### DIFF
--- a/lib/sax-machine/sax_document.rb
+++ b/lib/sax-machine/sax_document.rb
@@ -112,6 +112,14 @@ module SAXMachine
     def create_attr real_name
       attr_reader real_name unless method_defined?(real_name)
       attr_writer real_name unless method_defined?("#{real_name}=")
+
+      define_method "sax_machine_parsed_#{real_name}?" do
+        instance_variable_get("@sax_machine_parsed_#{real_name}") || false
+      end
+
+      define_method "sax_machine_parsed_#{real_name}!" do
+        instance_variable_set("@sax_machine_parsed_#{real_name}", true)
+      end
     end
   end
 

--- a/lib/sax-machine/sax_handler.rb
+++ b/lib/sax-machine/sax_handler.rb
@@ -15,7 +15,6 @@ module SAXMachine
 
     def initialize(object, on_error = nil, on_warning = nil)
       @stack = [ StackNode.new(object) ]
-      @parsed_configs = {}
       @on_error = on_error
       @on_warning = on_warning
     end
@@ -137,13 +136,18 @@ module SAXMachine
     private
 
     def mark_as_parsed(object, element_config)
-      unless element_config.collection?
-        @parsed_configs[[object.object_id, element_config.object_id]] = true
+      return if element_config.collection?
+      if object.respond_to?("sax_machine_parsed_#{element_config.column}!") then
+        object.send("sax_machine_parsed_#{element_config.column}!")
       end
     end
 
     def parsed_config?(object, element_config)
-      @parsed_configs[[object.object_id, element_config.object_id]]
+      if element_config.respond_to?(:column) then
+        if object.respond_to?("sax_machine_parsed_#{element_config.column}?") then
+          object.send("sax_machine_parsed_#{element_config.column}?")
+        end
+      end
     end
 
     def warning(string)


### PR DESCRIPTION
We were storing whether an object had been parsed or not in
@parsed_configs, inside SAXHandler, which was a huge memory leak in case
we wanted to parse really big files.

Created an instance variable in each element to store whether the
element_config was parsed already or not.

It feels a little bit dirty, but it's much better for garbage collection :)

Tests are passing.
