### PR TITLE
Support for Symbol data type conversion.

### DIFF
--- a/lib/sax-machine/handlers/sax_abstract_handler.rb
+++ b/lib/sax-machine/handlers/sax_abstract_handler.rb
@@ -60,6 +60,7 @@ module SAXMachine
             case element_config.data_class.to_s
             when "Integer" then 0
             when "Float"   then 0.0
+            when "Symbol"  then nil
             when "Time"    then Time.at(0)
             when ""        then object
             else
@@ -107,6 +108,12 @@ module SAXMachine
             when "String"  then value != NO_BUFFER ? value.to_s : value
             when "Integer" then value != NO_BUFFER ? value.to_i : value
             when "Float"   then value != NO_BUFFER ? value.to_f : value
+            when "Symbol"  then
+              if value != NO_BUFFER
+                value.to_s.empty? ? nil : value.to_s.downcase.to_sym
+              else
+                value
+              end
             # Assumes that time elements will be string-based and are not
             # something else, e.g. seconds since epoch
             when "Time"    then value != NO_BUFFER ? Time.parse(value.to_s) : value

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -182,6 +182,16 @@ describe "SAXMachine" do
           document = @klass.parse("<time>1994-02-04T06:20:00Z</time>")
           expect(document.time).to eq(Time.utc(1994, 2, 4, 6, 20, 0, 0))
         end
+
+        it "handles a Symbol class" do
+          @klass = Class.new do
+            include SAXMachine
+            element :symbol, class: Symbol
+          end
+
+          document = @klass.parse("<symbol>MY_SYMBOL_VALUE</symbol>")
+          expect(document.symbol).to eq(:my_symbol_value)
+        end
       end
 
       describe "the default attribute" do


### PR DESCRIPTION
``` ruby
require 'sax-machine'

class Fake
  include SAXMachine
  element :name
  element :status, class: Symbol
end

xml = '<fake><name>Prodis</name><status>sleepy</status></fake>'

fake = Fake.parse(xml)
fake.name   # => "Prodis"
fake.status # => :sleepy 
```
