### PR TITLE
Support for boolean data type conversion.

### DIFF
--- a/lib/sax-machine.rb
+++ b/lib/sax-machine.rb
@@ -2,6 +2,7 @@ require "sax-machine/version"
 require "sax-machine/sax_document"
 require "sax-machine/sax_configure"
 require "sax-machine/sax_config"
+require "wannabe_bool"
 
 module SAXMachine
   def self.handler

--- a/lib/sax-machine/handlers/sax_abstract_handler.rb
+++ b/lib/sax-machine/handlers/sax_abstract_handler.rb
@@ -61,11 +61,12 @@ module SAXMachine
 
         if !collection_config && element_config = sax_config.element_config_for_tag(name, attrs)
           new_object =
-            case element_config.data_class.to_s
-            when "Integer" then 0
-            when "Float"   then 0.0
-            when "Symbol"  then nil
-            when "Time"    then Time.at(0)
+            case element_config.data_class.to_s.downcase
+            when "integer" then 0
+            when "float"   then 0.0
+            when "boolean" then nil
+            when "symbol"  then nil
+            when "time"    then Time.at(0)
             when ""        then object
             else
               element_config.data_class.new
@@ -108,11 +109,12 @@ module SAXMachine
           object.send(config.accessor) << element
         else
           value =
-            case config.data_class.to_s
-            when "String"  then value != NO_BUFFER ? value.to_s : value
-            when "Integer" then value != NO_BUFFER ? value.to_i : value
-            when "Float"   then value != NO_BUFFER ? value.to_f : value
-            when "Symbol"  then
+            case config.data_class.to_s.downcase
+            when "string"  then value != NO_BUFFER ? value.to_s : value
+            when "integer" then value != NO_BUFFER ? value.to_i : value
+            when "float"   then value != NO_BUFFER ? value.to_f : value
+            when "boolean" then value != NO_BUFFER ? value.to_b : value
+            when "symbol"  then
               if value != NO_BUFFER
                 value.to_s.empty? ? nil : value.to_s.downcase.to_sym
               else
@@ -120,7 +122,7 @@ module SAXMachine
               end
             # Assumes that time elements will be string-based and are not
             # something else, e.g. seconds since epoch
-            when "Time"    then value != NO_BUFFER ? Time.parse(value.to_s) : value
+            when "time"    then value != NO_BUFFER ? Time.parse(value.to_s) : value
             when ""        then value
             else
               element

--- a/sax-machine.gemspec
+++ b/sax-machine.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.platform      = Gem::Platform::RUBY
 
+  s.add_dependency "wannabe_bool"
   s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -192,6 +192,19 @@ describe "SAXMachine" do
           document = @klass.parse("<symbol>MY_SYMBOL_VALUE</symbol>")
           expect(document.symbol).to eq(:my_symbol_value)
         end
+
+        it "handles boolean values" do
+          @klass = Class.new do
+            include SAXMachine
+            element :boolean, class: :boolean
+          end
+
+          document = @klass.parse("<boolean>true</boolean>")
+          expect(document.boolean).to eq(true)
+
+          document = @klass.parse("<boolean>false</boolean>")
+          expect(document.boolean).to eq(false)
+        end
       end
 
       describe "the default attribute" do


### PR DESCRIPTION
``` ruby
require 'sax-machine'

class Fake
  include SAXMachine
  element :name
  element :main, class: :boolean
  element :published, class: :boolean
end

xml = '<fake><name>Prodis</name><main>true</main><published>false</published></fake>'

fake = Fake.parse(xml)
fake.name      # => "Prodis"
fake.main      # => true 
fake.published # => false 
```
