### PR TITLE
fix uninitialized class variable error when nokogiri is used as handler

### DIFF
--- a/lib/sax-machine.rb
+++ b/lib/sax-machine.rb
@@ -5,12 +5,14 @@ require "sax-machine/sax_config"
 
 module SAXMachine
   def self.handler
-    @@handler
+    @@handler ||= nil
   end
 
   def self.handler=(handler)
-    require "sax-machine/handlers/sax_#{handler}_handler"
-    @@handler = handler
+    if handler
+      require "sax-machine/handlers/sax_#{handler}_handler"
+      @@handler = handler
+    end
   end
 end
 


### PR DESCRIPTION
when nokogiri is chosen as the handler `@@handler` is uninitialized
