### PR TITLE
Default value can't be `false`

### DIFF
--- a/lib/sax-machine/sax_document.rb
+++ b/lib/sax-machine/sax_document.rb
@@ -21,7 +21,7 @@ module SAXMachine
 
       self.class.sax_config.top_level_elements.each do |_, configs|
         configs.each do |config|
-          next unless config.default
+          next if config.default.nil?
           next unless send(config.as).nil?
 
           send(config.setter, config.default)

--- a/spec/sax-machine/sax_document_spec.rb
+++ b/spec/sax-machine/sax_document_spec.rb
@@ -207,6 +207,22 @@ describe "SAXMachine" do
           document = @klass.parse("<number></number>")
           expect(document.number).to eq(0)
         end
+
+        it "can be a Boolean" do
+          @klass = Class.new do
+            include SAXMachine
+            element(:bool, default: false) { |v| !!v }
+          end
+
+          document = @klass.parse("<no>bool</no>")
+          expect(document.bool).to be false
+
+          document = @klass.parse("<bool></bool>")
+          expect(document.bool).to be false
+
+          document = @klass.parse("<bool>1</bool>")
+          expect(document.bool).to be true
+        end
       end
 
       describe "the required attribute" do


### PR DESCRIPTION
Sometimes you want to parse tags/attributes as boolean values, and set a default if they are not present.
This is not possible right now.