### PR TITLE
Travis: drop unsupported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: ruby
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.2
-  - jruby-9.2.0.0
+  - 2.5.3
+  - jruby-9.2.5.0
   - ruby-head
   - jruby-head
 
@@ -19,11 +19,11 @@ env:
 matrix:
   exclude:
     - env: HANDLER="ox"
-      rvm: jruby-9.2.0.0
+      rvm: jruby-9.2.5.0
     - env: HANDLER="ox"
       rvm: jruby-head
   allow_failures:
     - env: HANDLER="oga"
-      rvm: jruby-9.2.0.0
+      rvm: jruby-9.2.5.0
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.2
   - jruby-9.2.0.0
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.8
-  - 2.4.6
   - 2.5.5
   - 2.6.2
-  - jruby-9.2.6.0
+  - jruby-9.2.13.0
   - ruby-head
   - jruby-head
 
@@ -18,11 +16,11 @@ env:
 matrix:
   exclude:
     - env: HANDLER="ox"
-      rvm: jruby-9.2.6.0
+      rvm: jruby-9.2.13.0
     - env: HANDLER="ox"
       rvm: jruby-head
   allow_failures:
     - env: HANDLER="oga"
-      rvm: jruby-9.2.6.0
+      rvm: jruby-9.2.13.0
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: ruby
 
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - jruby-9.2.5.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.2.6.0
   - ruby-head
   - jruby-head
-
-sudo: false
 
 env:
   matrix:
@@ -19,11 +18,11 @@ env:
 matrix:
   exclude:
     - env: HANDLER="ox"
-      rvm: jruby-9.2.5.0
+      rvm: jruby-9.2.6.0
     - env: HANDLER="ox"
       rvm: jruby-head
   allow_failures:
     - env: HANDLER="oga"
-      rvm: jruby-9.2.5.0
+      rvm: jruby-9.2.6.0
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - jruby-1.7
-  - rbx-2
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+  - jruby-9.2.0.0
   - ruby-head
   - jruby-head
 
@@ -21,12 +19,11 @@ env:
 matrix:
   exclude:
     - env: HANDLER="ox"
-      rvm: jruby-1.7
+      rvm: jruby-9.2.0.0
     - env: HANDLER="ox"
       rvm: jruby-head
   allow_failures:
     - env: HANDLER="oga"
-      rvm: jruby-1.7
-    - rvm: rbx-2
+      rvm: jruby-9.2.0.0
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
This PR was inspired by the build failure in #81.

It removes the no-longer-supported Ruby versions from the Travis CI matrix.

- Source for ruby versions: https://github.com/rbenv/ruby-build/tree/master/share/ruby-build
- 2.2 EOL announcement https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/