### PR TITLE
Update rails test to 6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   gem 'simplecov', require: false, platforms: [:mri]
   gem 'coveralls', require: false, platforms: [:mri]
 
-  gem 'activerecord', '~> 4.1'
+  gem 'activerecord', "~> 6.0"
   gem 'nokogiri', '~> 1.6'
   gem 'ox', '>= 2.1.2', platforms: [:mri, :rbx]
   gem 'oga', '>= 0.3.4'

--- a/spec/sax-machine/sax_activerecord_spec.rb
+++ b/spec/sax-machine/sax_activerecord_spec.rb
@@ -3,7 +3,9 @@ require 'active_record'
 
 describe "SAXMachine ActiveRecord integration" do
   before do
-    class MySaxModel < ActiveRecord::Base
+    class MySaxModel
+      include ActiveModel::Model
+
       SAXMachine.configure(MySaxModel) do |c|
         c.element :title
       end


### PR DESCRIPTION
This updates rails test to the current version. Rails now requires ActiveRecord classes to have a connection when they are created, so we can use include ActiveModel::Model to test the same thing.  This also allows the tests to be run on ruby 2.7 without warnings. The previous rails version was using a bigdecimal API that doesn't exist anymore.